### PR TITLE
disable `react/jsx-curly-spacing` as it conflicts with prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-calvium",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "eslint configuration to be used in Calvium React Native Projects",
   "main": "index.js",
   "scripts": {

--- a/rules/calvium.js
+++ b/rules/calvium.js
@@ -148,6 +148,7 @@ module.exports = {
     // disable
     'react/jsx-boolean-value': 0,
     'react/jsx-filename-extension': 0,
+    'react/jsx-curly-spacing': 0,
     // Causes errors in React Native <Text> elements if you use a '
     'react/no-unescaped-entities': 0,
     // disable as WebStorm marks this as an error


### PR DESCRIPTION
also bump 0.3.1

Fix issue where you have:

```lang=js
<WrapperComponent
      onPress={onPress}
      pointerEvents={onPress ? 'auto' : 'none' /* allow tap-through if not a button*/}
```

- eslint requires a space before the last } and prettier removes it