### PR TITLE
- Update dependencies to newest babel-eslint and plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+
+# ignore idea folder
+.idea/

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 Eslint Config Calvium
 =====================
 
-Current React Native tested versions from RN 0.39.0 to RN 0.43.0 but it may work in earliers too.
+Current React Native tested versions from `52.x` but it may work in earliers too.
 
 [eslint](http://eslint.org/)
 
@@ -26,12 +26,12 @@ after that you just need a `.eslintrc` in the same folder than the `package.json
 
 ##NOTES
 
-You **must** install the appropiate version of eslint for your project. A version bigger than `3.11.1` and below `4.x.x` is recommended.
+You **must** install the appropiate version of eslint for your project. Version 4 is recommended
 
 ```lang=bash
-npm i eslint@3 --save-dev
+npm i eslint@4 --save-dev
 #or
-yarn add eslint@3 --dev
+yarn add eslint@4 --dev
 ```
 
 To check the package is working in your installation run:

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: [
     'eslint-config-airbnb',
     './rules/calvium',
+'./rules/prettier'
   ].map(require.resolve),
   rules: {}
 };

--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
     "babel-eslint": "8.2.1",
     "eslint-config-airbnb": "16.1.0",
     "eslint-plugin-import": "2.8.0",
-    "eslint-plugin-flowtype": "2.41.0",
+    "eslint-plugin-flowtype": "2.42.0",
     "eslint-plugin-jsx-a11y": "6.0.3",
-    "eslint-plugin-react": "7.5.1",
+    "eslint-plugin-react": "7.6.1",
     "eslint-plugin-react-native": "3.2.1",
-    "eslint-plugin-promise": "3.6.0"
+    "eslint-plugin-promise": "3.6.0",
+    "eslint-config-prettier": "2.9.0"
   },
   "peerDependency": {
     "eslint": "4.x"

--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/calvium/eslint-config-calvium.git"
   },
-  "keywords": [
-    "eslint",
-    "calvium"
-  ],
+  "keywords": ["eslint", "calvium"],
   "author": "Pablo Carrillo",
   "license": "MIT",
   "bugs": {
@@ -27,7 +24,8 @@
     "eslint-plugin-flowtype": "2.41.0",
     "eslint-plugin-jsx-a11y": "6.0.3",
     "eslint-plugin-react": "7.5.1",
-    "eslint-plugin-react-native": "3.2.1"
+    "eslint-plugin-react-native": "3.2.1",
+    "eslint-plugin-promise": "3.6.0"
   },
   "peerDependency": {
     "eslint": "4.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-calvium",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "eslint configuration to be used in Calvium React Native Projects",
   "main": "index.js",
   "scripts": {
@@ -21,15 +21,15 @@
   },
   "homepage": "https://github.com/calvium/eslint-config-calvium#readme",
   "dependencies": {
-    "babel-eslint": "7.1.1",
-    "eslint-config-airbnb": "13.0.0",
-    "eslint-plugin-import": "2.2.0",
-    "eslint-plugin-flowtype": "2.29.1",
-    "eslint-plugin-jsx-a11y": "2.2.3",
-    "eslint-plugin-react": "6.8.0",
-    "eslint-plugin-react-native": "2.2.1"
+    "babel-eslint": "8.2.1",
+    "eslint-config-airbnb": "16.1.0",
+    "eslint-plugin-import": "2.8.0",
+    "eslint-plugin-flowtype": "2.41.0",
+    "eslint-plugin-jsx-a11y": "6.0.3",
+    "eslint-plugin-react": "7.5.1",
+    "eslint-plugin-react-native": "3.2.1"
   },
   "peerDependency": {
-    "eslint": "3.x"
+    "eslint": "4.x"
   }
 }

--- a/rules/calvium.js
+++ b/rules/calvium.js
@@ -172,6 +172,8 @@ module.exports = {
     'import/no-duplicates': 1,
     "react-native/no-unused-styles": 2,
     "react-native/no-color-literals": 2,
+    "react/prefer-stateless-function": [2, {"ignorePureComponents": true}],
+ "multiline": true }}]
     // Don't force () around `foo` in `foo => { .. do something }`
     "arrow-parens": 0,
     // I think it's ok to have class methods that could be static not static sometimes. (e.g. a `renderEmpty` method on a component)
@@ -198,7 +200,8 @@ module.exports = {
     "no-mixed-operators": 0,
     "no-confusing-arrow": 0,
     "react/jsx-wrap-multilines": 0,
-    "indent": 0
+    "indent": 0,
+     "object-curly-newline": [0, {"ObjectExpression": "always", "ObjectPattern": { "multiline": true }}]
     // .. end disabling for T6200
   },
   'settings': {

--- a/rules/calvium.js
+++ b/rules/calvium.js
@@ -5,6 +5,7 @@ module.exports = {
   },
   plugins: [
     'flowtype',
+    "promise",
     'react-native'
   ],
   parserOptions: {
@@ -56,13 +57,8 @@ module.exports = {
       0
     ],
     'no-return-assign': [0],
-    indent: [
-      'warn',
-      2,
-      {
-        SwitchCase: 1
-      }
-    ],
+    // Prettier deals with the indentation
+    indent: 0,
     'brace-style': [
       'warn',
       '1tbs'
@@ -71,9 +67,8 @@ module.exports = {
       'warn',
       'never'
     ],
-    'no-unused-vars': [
-      'warn'
-    ],
+    // used to denote unused arguments in callbacks
+    "no-unused-vars": ["warn", {"argsIgnorePattern": "^_"}],
     'arrow-body-style': [
       'warn',
       'as-needed'
@@ -173,7 +168,6 @@ module.exports = {
     "react-native/no-unused-styles": 2,
     "react-native/no-color-literals": 2,
     "react/prefer-stateless-function": [2, {"ignorePureComponents": true}],
- "multiline": true }}]
     // Don't force () around `foo` in `foo => { .. do something }`
     "arrow-parens": 0,
     // I think it's ok to have class methods that could be static not static sometimes. (e.g. a `renderEmpty` method on a component)
@@ -195,16 +189,24 @@ module.exports = {
         "message": "Please use Object.defineProperty instead."
       }
     ],
-    // used to denote unused arguments in callbacks
-    "no-unused-vars": ["warn", {"argsIgnorePattern": "^_"}],
     // Disabled due to conflict with Prettier (T6200)
     "react/jsx-closing-bracket-location": 0,
     "no-mixed-operators": 0,
     "no-confusing-arrow": 0,
     "react/jsx-wrap-multilines": 0,
-    "indent": 0,
-     "object-curly-newline": [0, {"ObjectExpression": "always", "ObjectPattern": { "multiline": true }}]
+    "object-curly-newline": [0, {"ObjectExpression": "always", "ObjectPattern": {"multiline": true}}],
     // .. end disabling for T6200
+    // Promise rules
+    "promise/always-return": "off",
+    "promise/no-return-wrap": "error",
+    "promise/param-names": "error",
+    "promise/catch-or-return": "error",
+    "promise/no-native": "off",
+    "promise/no-nesting": "warn",
+    "promise/no-promise-in-callback": "warn",
+    "promise/no-callback-in-promise": "warn",
+    "promise/avoid-new": "warn",
+    "promise/no-return-in-finally": "warn",
   },
   'settings': {
     flowtype: {

--- a/rules/calvium.js
+++ b/rules/calvium.js
@@ -6,7 +6,7 @@ module.exports = {
   plugins: [
     'flowtype',
     "promise",
-    'react-native'
+    'react-native',
   ],
   parserOptions: {
     ecmaFeatures: {

--- a/rules/calvium.js
+++ b/rules/calvium.js
@@ -195,6 +195,8 @@ module.exports = {
         "message": "Please use Object.defineProperty instead."
       }
     ],
+    // used to denote unused arguments in callbacks
+    "no-unused-vars": ["warn", {"argsIgnorePattern": "^_"}],
     // Disabled due to conflict with Prettier (T6200)
     "react/jsx-closing-bracket-location": 0,
     "no-mixed-operators": 0,

--- a/rules/calvium.js
+++ b/rules/calvium.js
@@ -205,8 +205,8 @@ module.exports = {
     "promise/no-nesting": "warn",
     "promise/no-promise-in-callback": "warn",
     "promise/no-callback-in-promise": "warn",
-    "promise/avoid-new": "warn",
-    "promise/no-return-in-finally": "warn",
+    "promise/avoid-new": "off",
+    "promise/no-return-in-finally": "off",
   },
   'settings': {
     flowtype: {

--- a/rules/calvium.js
+++ b/rules/calvium.js
@@ -13,9 +13,6 @@ module.exports = {
       jsx: true,
     },
   },
-  ecmaFeatures: {
-    jsx: true,
-  },
   globals: {
     fetch: false,
     '__DEV__': false,

--- a/rules/calvium.js
+++ b/rules/calvium.js
@@ -198,13 +198,13 @@ module.exports = {
     // .. end disabling for T6200
     // Promise rules
     "promise/always-return": "off",
-    "promise/no-return-wrap": "error",
+    "promise/no-return-wrap": "off",
     "promise/param-names": "error",
     "promise/catch-or-return": "error",
     "promise/no-native": "off",
-    "promise/no-nesting": "warn",
-    "promise/no-promise-in-callback": "warn",
-    "promise/no-callback-in-promise": "warn",
+    "promise/no-nesting": "off",
+    "promise/no-promise-in-callback": "off",
+    "promise/no-callback-in-promise": "off",
     "promise/avoid-new": "off",
     "promise/no-return-in-finally": "off",
   },

--- a/rules/prettier.js
+++ b/rules/prettier.js
@@ -1,0 +1,7 @@
+module.exports = {
+  // Jest Tests: Prevent 'it' and 'describe' causing ESLint errors
+  env: {
+    jest: true,
+  },
+  extends: ['prettier', 'prettier/flowtype', 'prettier/react'],
+};


### PR DESCRIPTION
- Update Readme
- eslint peer dependency is bump to 4.x
- Ignore idea directory
- add rule to prefer stateless functions but allow pure components
- Ignore extra rule as prettier deals with that
